### PR TITLE
Add support for explicit functions

### DIFF
--- a/commandr/__init__.py
+++ b/commandr/__init__.py
@@ -26,6 +26,7 @@ _COMMANDR = Commandr()
 
 command = _COMMANDR.command
 Run = _COMMANDR.Run
+RunFunction = _COMMANDR.RunFunction
 SetOptions = _COMMANDR.SetOptions
 
 # Export the decorator utils.


### PR DESCRIPTION
- Add a disptch method that takes an explicit function, circumventing the name
  based command function lookup.
- Also add an 'ignore_self' option, to help make commands from member
  functions.
