### PR TITLE
Adds Usage, list arguments, Validation and Transformation.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,19 +4,10 @@
   a specific command (help [command]).
 - The option 'help_docs' was added to print __main__.__doc__ on help messages.
   It defaults to True.
-- The option 'main' has been added to SetOptions and command() to set a command
+- The option main has been added to SetOptions and command() to set a command
   to get run when no command is supplied. Default is help.
 - The option 'ignore_self' can now be passed in command() to override the global
   value on a per function basis.
-- commandr.Usage(my_message) can now be called to print the Usage.
-- If an argument has a default that is a list, Commandr will now allow multiple
-  values for that list.
-- Arguments can now be validated during command parsing if
-  validate={argument_name=[..] or callable} is passed to command() or set as a
-  global option.
-- Arguments can now be transformed during command parsing if
-  transform={argument_name=callable} is passed to command() or set as a global
-  option.
 
 1.2.0
 ========

--- a/CHANGES
+++ b/CHANGES
@@ -1,10 +1,18 @@
+1.3.0
+======
+- commandr.CommandrUsageException(my_message) can now be raised in a commandr
+  run function to print Usage.
+- commandr.Usage(my_message) can now be called to print the Usage.
+- If an argument has a default that is a list, Commandr will now allow multiple
+  values for that list.
+
 1.2.1
 =======
 - The 'help' command has been added to give either the global help or help on
   a specific command (help [command]).
 - The option 'help_docs' was added to print __main__.__doc__ on help messages.
   It defaults to True.
-- The option main has been added to SetOptions and command() to set a command
+- The option 'main' has been added to SetOptions and command() to set a command
   to get run when no command is supplied. Default is help.
 - The option 'ignore_self' can now be passed in command() to override the global
   value on a per function basis.

--- a/CHANGES
+++ b/CHANGES
@@ -4,10 +4,19 @@
   a specific command (help [command]).
 - The option 'help_docs' was added to print __main__.__doc__ on help messages.
   It defaults to True.
-- The option main has been added to SetOptions and command() to set a command
+- The option 'main' has been added to SetOptions and command() to set a command
   to get run when no command is supplied. Default is help.
 - The option 'ignore_self' can now be passed in command() to override the global
   value on a per function basis.
+- commandr.Usage(my_message) can now be called to print the Usage.
+- If an argument has a default that is a list, Commandr will now allow multiple
+  values for that list.
+- Arguments can now be validated during command parsing if
+  validate={argument_name=[..] or callable} is passed to command() or set as a
+  global option.
+- Arguments can now be transformed during command parsing if
+  transform={argument_name=callable} is passed to command() or set as a global
+  option.
 
 1.2.0
 ========

--- a/README.md
+++ b/README.md
@@ -171,19 +171,6 @@ name with "no_" prefixed. For example, to set 'cache' to False for 'get':
 $ python features.py get somekey --no-cache
 ```
 
-### List Parameters
-
-If a parameter has a default value that is a list, Commandr will accept multiple
-values for the parameter, joining them together to form a list.  The type for
-the values in the list will be string.
-
-Multiple values can be specified by repeating the switch:
-```
-my-command --arg value1 --arg value2 --arg value3
-```
-will lead to:
-arg=[value1, value2, value3]
-
 ### Documentation Generation
 
 Command help is automatically generated, using the signature and docstring of
@@ -265,63 +252,10 @@ $ python features.py put somekey1 --transaction
 >   --transaction
 ```
 
-To print the usage message after the command is called, call
-commandr.Usage(message).  This will print the command usage and exit.
-
-### Value Transformation
-
-The value of an argument can be transformed before the command is called using
-the transform option on command() and global Options. To transform a value
-pass a dict with the argument name as a the key and a callable that accepts
-key and value as arguments and returns the new value of the argument.  If the
-value is None, transformation is not called.  Transformation will be called
-before Value Validation.
-
-An example:
-```
-def ConvertToDict(key, value):
-  """Converts str of format 'a=b;c=d;e=f' to a dict."""
-  if not isinstance(value, dict):
-    return dict(kv.split('=', 1) for kv in value.split(';'))
-  else:
-    # if value is not returned here, the new value will be None
-    return value
-
-@command(tranform={'extra':ConvertToDict},
-         validate={'extra':lambda k,v: 'msg' in extra})
-def MyFunction(name, extra={'msg':'Hi'}):
-```
-
-### Value Validation
-
-To validate the values passed as part of the argument parsing, pass a dict
-object to the command() function with key/value pairs where the value is
-either a list containing the passed value or a callable that accepts the
-argument name and argument value and returns True if the argument passes
-or False if it does not.  If the value is None, validation is not called.
-
-An example:
-```
-def IsCapitalized(key, name):
-  return name == str(name).capitalize()
-
-@command(validate={'title':['Mr', 'Mrs', 'Sir', 'Madam'],
-                   'first_name':IsCapitalized,
-                   'last_name':IsCapitalized})
-def MyFunction(title, first_name, last_name):
-  ...
-```
-
-It is also possible to declare a validation dict as a global option.  If it is
-set globally, any command that is run by Commandr will use the global
-validation if one of its arguments is in that dictionary.  However, A local
-validate for a @command will override the global validation.  See Options
-section for details on how to set Options.
-
 ### Options
 
 There are several options that can be set to modify the behavior of the parser
-generation. These options can be set by calling the SetOptions() function, or
+generation. These options can be set by calling the SeeOption() function, or
 as parameters to the Run() function. Values set by Run() take precedence.
 
 The available parameters are:
@@ -338,19 +272,6 @@ the command is run with no arguments or help.  Default is True.
 ##### main:
 If set, Commandr will use the supplied value as the command name to run
 if no command name is supplied.  It will override any previous values.
-
-##### validate:
-If set, Commandr will use the provided dict to set global Validation for any
-command that has an argument with a key in the dict.  If a global validate
-dict is set a second time, it will override all values in the original dict.
-If a command() passes a validate dict, it will only override values present
-in the local dict.   See the Validation section for details off the argument.
-
-##### transform:
-Sets the Global options for transformation (see Value Transformation).
-If set multiple times, the all values will be overridden by the last global
-option.  command(transform=..) options will override global options only for
-the values set in the local options.
 
 ##### hyphenate:
 If True (default), then any argument containing an underscore ('_') will be

--- a/README.md
+++ b/README.md
@@ -171,6 +171,19 @@ name with "no_" prefixed. For example, to set 'cache' to False for 'get':
 $ python features.py get somekey --no-cache
 ```
 
+### List Parameters
+
+If a parameter has a default value that is a list, Commandr will accept multiple
+values for the parameter, joining them together to form a list.  The type for
+the values in the list will be string.
+
+Multiple values can be specified by repeating the switch:
+```
+my-command --arg value1 --arg value2 --arg value3
+```
+will lead to:
+arg=[value1, value2, value3]
+
 ### Documentation Generation
 
 Command help is automatically generated, using the signature and docstring of
@@ -252,10 +265,14 @@ $ python features.py put somekey1 --transaction
 >   --transaction
 ```
 
+To print the usage message after the command is called, raise
+commandr.CommandrUsageError(message).  This will print the command usage and
+exit.
+
 ### Options
 
 There are several options that can be set to modify the behavior of the parser
-generation. These options can be set by calling the SeeOption() function, or
+generation. These options can be set by calling the SetOptions() function, or
 as parameters to the Run() function. Values set by Run() take precedence.
 
 The available parameters are:

--- a/commandr/__init__.py
+++ b/commandr/__init__.py
@@ -16,7 +16,6 @@ __all__ = [
     'command',
     'Run',
     'SetOptions',
-    'Usage',
     'update_wrapper',
     'wraps',
     'MonkeyPatchFunctools']
@@ -29,7 +28,6 @@ command = _COMMANDR.command
 Run = _COMMANDR.Run
 RunFunction = _COMMANDR.RunFunction
 SetOptions = _COMMANDR.SetOptions
-Usage = _COMMANDR.Usage
 
 # Export the decorator utils.
 from functools_util import update_wrapper, wraps, MonkeyPatchFunctools

--- a/commandr/__init__.py
+++ b/commandr/__init__.py
@@ -16,18 +16,28 @@ __all__ = [
     'command',
     'Run',
     'SetOptions',
+    'Usage',
     'update_wrapper',
     'wraps',
-    'MonkeyPatchFunctools']
+    'MonkeyPatchFunctools',
+    'CommandrError',
+    'CommandrUsageError',
+    'CommandrDuplicateMainError']
 
 # Export the global Commandr object methods.
-from commandr import Commandr
+from commandr import (
+  Commandr,
+  CommandrError,
+  CommandrUsageError,
+  CommandrDuplicateMainError)
+
 _COMMANDR = Commandr()
 
 command = _COMMANDR.command
 Run = _COMMANDR.Run
 RunFunction = _COMMANDR.RunFunction
 SetOptions = _COMMANDR.SetOptions
+Usage = _COMMANDR.Usage
 
 # Export the decorator utils.
 from functools_util import update_wrapper, wraps, MonkeyPatchFunctools

--- a/commandr/__init__.py
+++ b/commandr/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     'command',
     'Run',
     'SetOptions',
+    'Usage',
     'update_wrapper',
     'wraps',
     'MonkeyPatchFunctools']
@@ -28,6 +29,7 @@ command = _COMMANDR.command
 Run = _COMMANDR.Run
 RunFunction = _COMMANDR.RunFunction
 SetOptions = _COMMANDR.SetOptions
+Usage = _COMMANDR.Usage
 
 # Export the decorator utils.
 from functools_util import update_wrapper, wraps, MonkeyPatchFunctools

--- a/commandr/commandr.py
+++ b/commandr/commandr.py
@@ -90,7 +90,7 @@
 #
 # There are several options that affect the form of the generated parser. The
 # options can be set by calling:
-#   SetOption(hyphenate=<bool>, show_all_help_variants=<bool>)
+#   SetOptions(hyphenate=<bool>, show_all_help_variants=<bool>)
 #
 # All options can also be set as arguments to Run(). Values set in that way
 # will take precedence.
@@ -138,6 +138,9 @@ class Commandr(object):
     self.hidden = True
     self.ignore_self = False
     self.main_docs = True
+    self.main = None
+    self.validate = None
+    self.transform = None
 
     # Internal flag indicating whether to expect the command name as the first
     # command line argument.
@@ -146,18 +149,19 @@ class Commandr(object):
     # Mapping of all command names to the respective command function.
     self.parser = None
     self._all_commands = {}
-    self.main = None
+    self.current_command = None
 
     # List of commands in the order they appeared, of the format:
     #   [(name, callable, category)]
     self._command_list = []
     self._command_info = namedtuple(
-      '_COMMAND_INFO', ['name', 'callable', 'category', 'ignore_self'])
+      '_COMMAND_INFO', ['name', 'callable', 'category', 'ignore_self',
+                        'validate', 'transform'])
 
     self.command('help', ignore_self=True)(self._HelpExitNoCommand)
 
   def command(self, command_name=None, category=None, main=False,
-              ignore_self=None):
+              ignore_self=None, validate=None, transform=None):
     """Decorator that marks a function as a 'command' which can be invoked with
     arguments from the command line. e.g.:
 
@@ -178,6 +182,11 @@ class Commandr(object):
         main.
       ignore_self - If True or False, it will apply the ignore_self option for
         this command, while others use the global default.
+      validate - A dict of key/list pairs that limit the possible values
+        returned for a specific argument.
+      transform - A key/callable dict that will call the callable if the
+          argument is a key.  It will set the value to whatever the callable
+          returns.  This runs before validation.
     Returns:
       decorator/function to register the command.
     """
@@ -185,7 +194,8 @@ class Commandr(object):
       final_name = (cmd_fn_name if cmd_fn_name is not None
                     else command_name if command_name is not None
                     else cmd_fn.func_name)
-      info = self._command_info(final_name, cmd_fn, category, ignore_self)
+      info = self._command_info(final_name, cmd_fn, category, ignore_self,
+                                validate or {}, transform or {})
       self._all_commands[final_name] = info
       if main:
         if not self.main:
@@ -208,7 +218,9 @@ class Commandr(object):
       show_all_help_variants=None,
       ignore_self=None,
       main_docs=None,
-      main=None):
+      main=None,
+      validate=None,
+      transform=None):
     """Set commandr options. Any argument not set to None will be applied
     (otherwise it will retain its current value).
 
@@ -226,6 +238,14 @@ class Commandr(object):
           command is specified.  Default is True.
       main - If set, it will use the supplied value as the command name to run
           if no command name is supplied.  It will override any previous values.
+      validate - If a dict of key/list or callable is provided, it will
+          require any command called that has that key as an argument to limit
+          the allowed values.   If a list is provided for the key, the argument
+          must be in that list.  If a callable is provided, it will be called
+          with the value as an argument.
+      transform - A key/callable dict that will call the callable if the
+          argument is a key.  It will set the value to whatever the callable
+          returns.  This runs before validation.
     """
     # Anything added here should also be added to the RunFunction interface.
     if hyphenate is not None:
@@ -238,6 +258,10 @@ class Commandr(object):
       self.main_docs = main_docs
     if main is not None:
       self.main = main
+    if validate is not None:
+      self.validate = validate
+    if transform is not None:
+      self.transform = transform
 
   def Run(self, *args, **kwargs):
     """Main function to take command line arguments, and parse them into a
@@ -279,7 +303,9 @@ class Commandr(object):
       show_all_help_variants=None,
       ignore_self=None,
       main_doc=None,
-      main=None):
+      main=None,
+      validate=None,
+      transform=None):
     """Method to explicitly execute a given function against the command line
     arguments. If this method is called directly, the command name will not be
     expected in the arguments.
@@ -297,15 +323,24 @@ class Commandr(object):
           command is specified.  Default is True.
       main - If set, it will use the supplied value as the command name to run
           if no command name is supplied.  It will override any previous values.
+      validate - If a dict of key/list or callable is provided, it will
+          require any command called that has that key as an argument to limit
+          the allowed values.   If a list is provided for the key, the argument
+          must be in that list.  If a callable is provided, it will be called
+          with the value as an argument.
+      transform - A key/callable dict that will call the callable if the
+          argument is a key.  It will set the value to whatever the callable
+          returns.  This runs before validation.
     """
     self.SetOptions(hyphenate, show_all_help_variants, ignore_self, main_doc,
-                    main)
+                    main, validate, transform)
 
     cmd_name = cmd_name or ""
 
     argspec, defaults_dict = self._BuildOptParse(cmd_name)
 
     (options, args) = self.parser.parse_args()
+
     options_dict = vars(options)
 
     # If help, print our message, else remove it so it doesn't confuse the
@@ -315,14 +350,14 @@ class Commandr(object):
     elif 'help' in options_dict:
       del options_dict['help']
 
-    info = self._all_commands.get(cmd_name) or self._command_info()
+    info = (self._all_commands.get(cmd_name)
+            or self._command_info(cmd_name, cmd_fn))
     ignore = (info.ignore_self
               if info.ignore_self is not None
               else self.ignore_self)
 
     # If desired, add args into the options_dict
     args_to_parse = args[1:] if not self.no_command_arg else args
-
     if len(args_to_parse) > 0:
       skipped = 0
 
@@ -349,8 +384,9 @@ class Commandr(object):
 
         # Make sure the arg isn't already changed from the default.
         if (((key in defaults_dict and defaults_dict[key] != options_dict[key])
-             or (key not in defaults_dict and options_dict[key] != None))
-            and value != options_dict[key]):
+             or (key not in defaults_dict and options_dict[key] is not None))
+            and value != options_dict[key]
+            and not isinstance(defaults_dict[key], list)):
           self._HelpExitCommand(
               "Repeated option: %s\nOption: %s\nArgument: %s" % (
                   key, options_dict[key], value),
@@ -362,16 +398,71 @@ class Commandr(object):
             value = int(value)
           elif isinstance(defaults_dict[key], float):
             value = float(value)
-
+          elif  isinstance(defaults_dict[key], list):
+            if options_dict[key] is None:
+              value = options_dict[key] = [value]
+            else:
+              value = options_dict[key] + [value]
         # Update arg
         options_dict[key] = value
 
+    transforms = self.transform or {}
+    transforms.update(info.transform or {})
+    possible = self.validate or {}
+    possible.update(info.validate or {})
     for key, value in options_dict.iteritems():
-      if value == None and key not in defaults_dict:
-        self._HelpExitCommand(
+      if value is None:
+        if key not in defaults_dict:
+          self._HelpExitCommand(
             "All options without default values must be specified",
             cmd_name, cmd_fn, options_dict, argspec.args)
+        elif defaults_dict[key] is not None:
+          value = options_dict[key] = defaults_dict[key]
+      if value is not None:
+        message = None
+        # Transform
+        if key in transforms:
+          try:
+            options_dict[key] = value = transforms[key](key, value)
+          except Exception as e:
+            # If there was an error, set the error message
+            message = "Invalid value: %s=%s\n%s" % (key, value, str(e))
 
+        # Validate if there isn't an error message
+        if not message and key in possible:
+          # convert everything to list for convenience
+          val = [value] if not isinstance(value, list) else value
+          # figure out the check  (user callable or list check)
+          if callable(possible[key]):
+            check = possible[key]
+          else:
+            check = lambda k, v: v in possible[k]
+          error = None
+          # If there's an error in checking all values, catch it and make a
+          # message.
+          try:
+            success = all(check(key, v) for v in val)
+          except Exception as e:
+            success = False
+            error = str(e)
+          # Report if the check didn't pass
+          if not success:
+            message = "Invalid value for %s: %s" % (key, ",".join(val))
+            if isinstance(possible[key], list):
+              message += " not in [%s]" % (",".join(str(v)
+                                                    for v in possible[key]))
+            elif hasattr(check, '__doc__') and check.__doc__:
+              # Take the doc until the first empty line
+              doc = itertools.takewhile(
+                bool, [l.strip() for l in check.__doc__.split('\n')])
+              message += '\n' + " ".join(doc)
+            if error:
+              message += '\n' + error
+        if message:
+          self._HelpExitCommand(message, cmd_name, cmd_fn, options_dict,
+                                argspec.args)
+                                  
+    self.current_command = info
     result = cmd_fn(**options_dict)
 
     if result:
@@ -449,6 +540,9 @@ class Commandr(object):
         elif repr(defaults_dict[arg]) == 'True':
           self._AddOption(args, dest=arg, action='store_false',
                       default=True)
+        elif isinstance(defaults_dict[arg], list):
+          self._AddOption(args, dest=arg, action='append',
+                          type='string')
         else:
           if isinstance(defaults_dict[arg], int):
             arg_type = 'int'
@@ -507,6 +601,14 @@ class Commandr(object):
       if 'default' in kwargs_hidden:
         del kwargs_hidden['default']
       self.parser.add_option(*args_hidden, **kwargs_hidden)
+
+  def Usage(self, message=None):
+    """Prints out a Usage message and exits."""
+    if self.current_command:
+      self._HelpExitCommand(message, self.current_command.name,
+                            self.current_command.callable)
+    else:
+      self._HelpExitNoCommand(message=message)
 
   def _HelpExitNoCommand(self, cmd_name=None, message=None):
     """Prints the global help message listing all commands.
@@ -582,7 +684,11 @@ class Commandr(object):
         arglist = sorted(options_dict.keys())
       print "Current Options:"
       for arg in arglist:
-        print " --%s=%s" % (arg, options_dict[arg])
+        arg_start =  " --%s=" % arg
+        arg_list = (arg_start.join(str(a) for a in options_dict[arg])
+                    if isinstance(options_dict[arg], list)
+                    else str(options_dict[arg]))
+        print "%s%s" % (arg_start, arg_list)
       print ""
 
     # Emit the documentation for the command.

--- a/example.py
+++ b/example.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 #
 # =============================================================================
-#
-# Example usage of commandr.
-#
+"""Example usage of commandr."""
 
-from commandr import command, Run, wraps
+from commandr import command, Run, CommandrUsageError, wraps
 
 @command('greet')
 def SayGreeting(name, title='Mr.', times=1, comma=False, caps_lock=False):
@@ -39,11 +37,13 @@ def SayGreeting(name, title='Mr.', times=1, comma=False, caps_lock=False):
 
 @command
 def simple_greet(name):
-  """An example of @command without arguments.
+  """An example of @command without arguments and printing Usage.
 
   Arguments:
     name - Name to greet.
   """
+  if name == 'John':
+    raise CommandrUsageError("John is not a valid name.")
   print 'Hi %s!' % name
 
 @command()

--- a/example.py
+++ b/example.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 #
 # =============================================================================
-"""Example usage of commandr."""
+#
+# Example usage of commandr.
+#
 
-from commandr import command, Run, Usage, wraps
+from commandr import command, Run, wraps
 
 @command('greet')
 def SayGreeting(name, title='Mr.', times=1, comma=False, caps_lock=False):
@@ -37,37 +39,21 @@ def SayGreeting(name, title='Mr.', times=1, comma=False, caps_lock=False):
 
 @command
 def simple_greet(name):
-  """An example of @command without arguments and printing Usage.
+  """An example of @command without arguments.
 
   Arguments:
     name - Name to greet.
   """
-  if name == 'John':
-    Usage("We don't like John")
   print 'Hi %s!' % name
 
-def ConvertToDict(key, value):
-  """Converts str of format 'a=b;c=d;e=f' to a dict."""
-  if not isinstance(value, dict):
-    return dict(kv.split('=', 1) for kv in value.split(';'))
-  else:
-    # if value is not returned here, the new value will be None
-    return value
-
-@command(validate={'name':['Kevin', 'Nick', 'Mike', 'Wade']},
-         transform={'name':lambda k,v: v.capitalize(),
-                    'extra':ConvertToDict})
-def another_simple_greet(name=None, extra={'hi':'Aloha', 'end':'!'}):
-  """An example of @command(), specifying the possible values for name.
-
-  This overrides the global capitalization check.
+@command()
+def another_simple_greet(name):
+  """An example of @command() without arguments.
 
   Arguments:
-    name - Name to greet.  It must be capitalized.
-    extra - Containing the 'hi' message and the end of the sentence '!'.
-            Format: --extra "hi=Hi;end=..."
+    name - Name to greet.
   """
-  print '%s %s%s' % (extra['hi'], name, extra['end'])
+  print 'Aloha %s!' % name
 
 def some_decorator(fn):
   @wraps(fn)
@@ -82,14 +68,5 @@ def DecoratedFunction(arg1, arg2=1):
     """An example usage of stacked decorators."""
     print arg1, arg2
 
-def NameCheck(arg_name, arg_value):
-  """A name must be capitalized.
-
-  This doc will be printed up to the first empty line if the check fails.
-  """
-  return arg_value == arg_value.capitalize()
-
 if __name__ == '__main__':
-  # This requires every command that uses 'name' as an argument to make sure
-  # that name is capitalized, unless the possible_value is overridden.
-  Run(hyphenate=True, validate={'name':NameCheck})
+  Run(hyphenate=True)

--- a/example.py
+++ b/example.py
@@ -13,11 +13,9 @@
 # limitations under the License.
 #
 # =============================================================================
-#
-# Example usage of commandr.
-#
+"""Example usage of commandr."""
 
-from commandr import command, Run, wraps
+from commandr import command, Run, Usage, wraps
 
 @command('greet')
 def SayGreeting(name, title='Mr.', times=1, comma=False, caps_lock=False):
@@ -39,21 +37,37 @@ def SayGreeting(name, title='Mr.', times=1, comma=False, caps_lock=False):
 
 @command
 def simple_greet(name):
-  """An example of @command without arguments.
+  """An example of @command without arguments and printing Usage.
 
   Arguments:
     name - Name to greet.
   """
+  if name == 'John':
+    Usage("We don't like John")
   print 'Hi %s!' % name
 
-@command()
-def another_simple_greet(name):
-  """An example of @command() without arguments.
+def ConvertToDict(key, value):
+  """Converts str of format 'a=b;c=d;e=f' to a dict."""
+  if not isinstance(value, dict):
+    return dict(kv.split('=', 1) for kv in value.split(';'))
+  else:
+    # if value is not returned here, the new value will be None
+    return value
+
+@command(validate={'name':['Kevin', 'Nick', 'Mike', 'Wade']},
+         transform={'name':lambda k,v: v.capitalize(),
+                    'extra':ConvertToDict})
+def another_simple_greet(name=None, extra={'hi':'Aloha', 'end':'!'}):
+  """An example of @command(), specifying the possible values for name.
+
+  This overrides the global capitalization check.
 
   Arguments:
-    name - Name to greet.
+    name - Name to greet.  It must be capitalized.
+    extra - Containing the 'hi' message and the end of the sentence '!'.
+            Format: --extra "hi=Hi;end=..."
   """
-  print 'Aloha %s!' % name
+  print '%s %s%s' % (extra['hi'], name, extra['end'])
 
 def some_decorator(fn):
   @wraps(fn)
@@ -68,5 +82,14 @@ def DecoratedFunction(arg1, arg2=1):
     """An example usage of stacked decorators."""
     print arg1, arg2
 
+def NameCheck(arg_name, arg_value):
+  """A name must be capitalized.
+
+  This doc will be printed up to the first empty line if the check fails.
+  """
+  return arg_value == arg_value.capitalize()
+
 if __name__ == '__main__':
-  Run(hyphenate=True)
+  # This requires every command that uses 'name' as an argument to make sure
+  # that name is capitalized, unless the possible_value is overridden.
+  Run(hyphenate=True, validate={'name':NameCheck})


### PR DESCRIPTION
- commandr.Usage(my_message) can now be called to print the Usage.
- If an argument has a default that is a list, Commandr will now allow multiple
  values for that list.
- Arguments can now be validated during command parsing if
  validate={argument_name=[..] or callable} is passed to command() or set as a
  global option.
- Arguments can now be transformed during command parsing if
  transform={argument_name=callable} is passed to command() or set as a global
  option.
